### PR TITLE
fix(docs): Don't install docs on postinstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ export default App;
 
 See more at https://nordnet.github.io/grid/
 
+## Example (docs)
+
+(`yarn` is interchangable with `npm` in this example)
+
+```sh
+yarn run docs:install
+# then
+yarn run docs:start
+```
+
 ## License
 
 MIT © [Nordnet Bank AB](https://www.nordnet.se)

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
     "dist"
   ],
   "scripts": {
-    "postinstall": "onpm docs install",
     "precommit": "lint-staged",
     "commit": "git-cz",
     "commitmsg": "validate-commit-msg",
     "prepush": "run-s test",
     "start": "run-p watch docs:start",
+    "docs:install": "onpm docs install",
     "docs:start": "onpm docs start",
     "predocs:deploy": "run-s build",
     "docs:deploy": "onpm docs run deploy",


### PR DESCRIPTION
Describe how to install and start a local version of the docs in the readme instead.