### PR TITLE
fix(col): fixed missing offset classes

### DIFF
--- a/src/col/styles.js
+++ b/src/col/styles.js
@@ -1,6 +1,7 @@
 import { media, gutter, columns, breakpoints } from '../spec';
 
-const range = x => new Array(x).fill('').map((_, i) => i + 1);
+const range = (x, firstIndex) =>
+  new Array(x).fill('').map((_, i) => i + firstIndex);
 
 const styles = {
   col: {
@@ -13,7 +14,7 @@ const styles = {
     'flex-direction': 'column-reverse',
   },
 };
-const _size = i => Number(100 / columns * i).toFixed(4);
+const _size = i => Number((100 / columns) * i).toFixed(4);
 
 const helpers = {
   basic: {
@@ -41,7 +42,7 @@ Object.keys(breakpoints).forEach(breakpoint => {
     .map(key => ({ key, helper: helpers[key] }))
     .forEach(({ key, helper }) => {
       if (key === 'size' || key === 'offset') {
-        range(columns).forEach(colIndex => {
+        range(columns, key === 'size' ? 1 : 0).forEach(colIndex => {
           styles[`${breakpoint}-${key}-${colIndex}`] = {
             [media(breakpoint)]: helper(colIndex),
           };


### PR DESCRIPTION
there were no 0 offset classes generated, making it impossible to remove offset set by smaller
breakpoints

BREAKING CHANGE: could potentially change layout for users who have set offSet to 0 but not seen any change

Example:
https://stackblitz.com/edit/react-vkb39k?file=index.js
https://react-vkb39k.stackblitz.io
change the size of the window and observe

`smOffset={0}` should get rid of the offset from `xs` but it stays because no `sm-offset-0` class is generated so none are applied

https://github.com/kristoferjoseph/flexboxgrid/blob/master/src/css/flexboxgrid.css here you can see that there should be `*-offset-0` classes